### PR TITLE
Remove max version 1.99.99

### DIFF
--- a/InitialContracts.netkan
+++ b/InitialContracts.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : "v1.2",
+    "spec_version"   : "v1.4",
     "identifier"     : "ContractConfigurator-InitialContracts",
     "name"           : "Contract Pack: Initial Contracts",
     "$kref"          : "#/ckan/kerbalstuff/577",

--- a/InitialContracts.netkan
+++ b/InitialContracts.netkan
@@ -1,10 +1,9 @@
 {
     "spec_version"   : "v1.2",
-    "identifier"     : "ContractConfigurator-InitialContracts", 
+    "identifier"     : "ContractConfigurator-InitialContracts",
     "name"           : "Contract Pack: Initial Contracts",
     "$kref"          : "#/ckan/kerbalstuff/577",
     "x_netkan_license_ok" : true,
-    "ksp_version_max": "1.99.99",
     "depends" : [
         { "name": "ContractConfigurator" },
         { "name": "ModuleManager" }

--- a/PartOverhaulsSETI.netkan
+++ b/PartOverhaulsSETI.netkan
@@ -1,7 +1,7 @@
 {
     "$kref" : "#/ckan/github/Y3mo/PartOverhaulsSETI",
     "$vref" : "#/ckan/ksp-avc",
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "name": "Porkjets PartOverhauls - SETIconfig",
     "identifier": "PartOverhaulsSETI",
     "abstract"     : "Porkjets PartOverhauls with SETI configs. Uses parts as additions instead of replacements of stock parts, thus compatible with VenStockRevamp. Boattail parts 1.25m diameter. Non-boattail parts 0.625m diameter and full set of 1.875m parts, including adapters, decoupler and nosecone. Removes upgrades until that feature is properly implemented.",

--- a/PartOverhaulsSETI.netkan
+++ b/PartOverhaulsSETI.netkan
@@ -6,7 +6,6 @@
     "identifier": "PartOverhaulsSETI",
     "abstract"     : "Porkjets PartOverhauls with SETI configs. Uses parts as additions instead of replacements of stock parts, thus compatible with VenStockRevamp. Boattail parts 1.25m diameter. Non-boattail parts 0.625m diameter and full set of 1.875m parts, including adapters, decoupler and nosecone. Removes upgrades until that feature is properly implemented.",
     "license"	: "CC-BY-NC-3.0",
-    "ksp_version_max": "1.99.99",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
     },
@@ -14,9 +13,9 @@
     	{ "name" : "ModuleManager" }
     ],
     "install" : [
-    	{ 
+    	{
         "find" : "PartOverhaulsSETI",
-	      "install_to" : "GameData" 
-      } 
+	      "install_to" : "GameData"
+      }
     ]
 }

--- a/SETI-BalanceMod.netkan
+++ b/SETI-BalanceMod.netkan
@@ -5,7 +5,6 @@
     "name"          : "SETI-Rebalance",
     "identifier"    : "SETI-BalanceMod",
     "x_netkan_license_ok" : true,
-    "ksp_version_max": "1.99.99",
     "depends" : [
         { "name": "ModuleManager" }
     ],
@@ -13,11 +12,11 @@
     		{ "name": "KSP-AVC" }
     ],
     "install" : [
-        { 
+        {
           "find"       : "SETIrebalance",
           "install_to" : "GameData"
         },
-        { 
+        {
           "find"       : "SETIrebalanceReactionWheels",
           "install_to" : "GameData"
         }

--- a/SETI-BalanceMod.netkan
+++ b/SETI-BalanceMod.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"  : "v1.2",
+    "spec_version"  : "v1.4",
     "$kref"         : "#/ckan/spacedock/14",
     "$vref"         : "#/ckan/ksp-avc",
     "name"          : "SETI-Rebalance",

--- a/SETI-CareerChallenge.netkan
+++ b/SETI-CareerChallenge.netkan
@@ -1,21 +1,21 @@
 {
-  "$kref"         : "#/ckan/github/Y3mo/SETI-CareerChallenge",
-  "$vref"         : "#/ckan/ksp-avc",
-  "spec_version"  : 1,
-  "name"          : "SETI-CareerChallenge",
-  "identifier"    : "SETI-CareerChallenge",
-  "abstract"      : "Reduces experiment science by 70% to somewhat balance out the science gained from contracts in career mode, compared to science mode.",
-  "license"       : "restricted",
-  "resources"     : {
-    "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
-  },
-  "depends"       : [
-    { "name"      : "ModuleManager" }
-  ],
-  "install"       : [
-    {
-      "find"      : "SETIcareerChallenge",
-      "install_to" : "GameData"
-    }
-  ]
+    "$kref"         : "#/ckan/github/Y3mo/SETI-CareerChallenge",
+    "$vref"         : "#/ckan/ksp-avc",
+    "spec_version"  : "v1.4",
+    "name"          : "SETI-CareerChallenge",
+    "identifier"    : "SETI-CareerChallenge",
+    "abstract"      : "Reduces experiment science by 70% to somewhat balance out the science gained from contracts in career mode, compared to science mode.",
+    "license"       : "restricted",
+    "resources"     : {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
+    },
+    "depends"       : [
+        { "name"      : "ModuleManager" }
+    ],
+    "install"       : [
+        {
+            "find"      : "SETIcareerChallenge",
+            "install_to" : "GameData"
+        }
+    ]
 }

--- a/SETI-CareerChallenge.netkan
+++ b/SETI-CareerChallenge.netkan
@@ -6,7 +6,6 @@
   "identifier"    : "SETI-CareerChallenge",
   "abstract"      : "Reduces experiment science by 70% to somewhat balance out the science gained from contracts in career mode, compared to science mode.",
   "license"       : "restricted",
-  "ksp_version_max" : "1.99.99",
   "resources"     : {
     "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
   },
@@ -14,9 +13,9 @@
     { "name"      : "ModuleManager" }
   ],
   "install"       : [
-    { 
+    {
       "find"      : "SETIcareerChallenge",
-      "install_to" : "GameData" 
-    } 
+      "install_to" : "GameData"
+    }
   ]
 }

--- a/SETI-Contracts.netkan
+++ b/SETI-Contracts.netkan
@@ -4,7 +4,6 @@
     "$vref"         : "#/ckan/ksp-avc",
     "identifier"    : "SETI-Contracts",
     "x_netkan_license_ok" : true,
-    "ksp_version_max": "1.99.99",
     "depends" : [
         { "name": "ContractConfigurator" },
         { "name": "ModuleManager" }
@@ -19,7 +18,7 @@
         { "name": "WaypointManager" }
     ],
     "install" : [
-        { 
+        {
           "file"       : "SETIcontracts",
           "install_to" : "GameData"
         }

--- a/SETI-CustomBarnKit.netkan
+++ b/SETI-CustomBarnKit.netkan
@@ -1,22 +1,22 @@
 {
-  "$kref"         : "#/ckan/github/Y3mo/SETI-CustomBarnKit",
-  "$vref"         : "#/ckan/ksp-avc",
-  "spec_version"  : 1,
-  "name"          : "SETI-CustomBarnKit-Config (EXPERIMENTAL)",
-  "identifier"    : "SETI-CustomBarnKit",
-  "abstract"      : "EXPERIMENTAL: Use at your own risk at this time. This is a SETI config for CustomBarnKit, increasing the number of building upgrade levels and tweaking unlocks (eg action groups available from the start). Especially balanced for SETIrebalance mod pack.",
-  "license"       : "MIT",
-  "resources"     : {
-    "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
-  },
-  "depends"       : [
-    { "name"      : "ModuleManager" },
-    { "name"      : "CustomBarnKit" }
-  ],
-  "install"       : [
-    {
-      "find"      : "SETIcustomBarnKitConfig",
-      "install_to" : "GameData"
-    }
-  ]
+    "$kref"         : "#/ckan/github/Y3mo/SETI-CustomBarnKit",
+    "$vref"         : "#/ckan/ksp-avc",
+    "spec_version" : "v1.4",
+    "name"          : "SETI-CustomBarnKit-Config (EXPERIMENTAL)",
+    "identifier"    : "SETI-CustomBarnKit",
+    "abstract"      : "EXPERIMENTAL: Use at your own risk at this time. This is a SETI config for CustomBarnKit, increasing the number of building upgrade levels and tweaking unlocks (eg action groups available from the start). Especially balanced for SETIrebalance mod pack.",
+    "license"       : "MIT",
+    "resources"     : {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
+    },
+    "depends"       : [
+        { "name"      : "ModuleManager" },
+        { "name"      : "CustomBarnKit" }
+    ],
+    "install"       : [
+        {
+            "find"      : "SETIcustomBarnKitConfig",
+            "install_to" : "GameData"
+        }
+    ]
 }

--- a/SETI-CustomBarnKit.netkan
+++ b/SETI-CustomBarnKit.netkan
@@ -6,7 +6,6 @@
   "identifier"    : "SETI-CustomBarnKit",
   "abstract"      : "EXPERIMENTAL: Use at your own risk at this time. This is a SETI config for CustomBarnKit, increasing the number of building upgrade levels and tweaking unlocks (eg action groups available from the start). Especially balanced for SETIrebalance mod pack.",
   "license"       : "MIT",
-  "ksp_version_max" : "1.99.99",
   "resources"     : {
     "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
   },
@@ -15,9 +14,9 @@
     { "name"      : "CustomBarnKit" }
   ],
   "install"       : [
-    { 
+    {
       "find"      : "SETIcustomBarnKitConfig",
-      "install_to" : "GameData" 
-    } 
+      "install_to" : "GameData"
+    }
   ]
 }

--- a/SETI-Greenhouse.netkan
+++ b/SETI-Greenhouse.netkan
@@ -3,14 +3,13 @@
   "spec_version"    : 1,
   "identifier"      : "SETI-Greenhouse",
   "license"         : "CC-BY-NC-SA-3.0",
-  "ksp_version_max" : "1.99.99",
   "depends"         : [
     { "name"  : "ModuleManager" }
   ],
   "install"         : [
-    { 
+    {
       "file"  : "SETIgreenhouse",
-      "install_to"  : "GameData" 
-    } 
+      "install_to"  : "GameData"
+    }
   ]
 }

--- a/SETI-MetaModPack.netkan
+++ b/SETI-MetaModPack.netkan
@@ -6,7 +6,6 @@
     "identifier": "SETI-MetaModPack",
     "abstract"     : "This is the fulcrum for the SETI meta mod pack. Only select this mod in CKAN, then click ApplyChanges and accept all recommendations and optionally the suggestions you like, to get a more balanced and challenging KSP experience!",
     "license"	: "restricted",
-    "ksp_version_max": "1.99.99",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
     },
@@ -110,9 +109,9 @@
 		{ "name": "ThrottleControlledAvionics" }
     ],
     "install" : [
-    	{ 
+    	{
         "find" : "SETImetaModPack",
-        "install_to" : "GameData" 
-      	} 
+        "install_to" : "GameData"
+      	}
     ]
 }

--- a/SETI-ProbeControlEnabler.netkan
+++ b/SETI-ProbeControlEnabler.netkan
@@ -1,7 +1,7 @@
 {
     "$kref" : "#/ckan/github/Y3mo/SETI-ProbeControlEnabler",
     "$vref" : "#/ckan/ksp-avc",
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "name": "RemoteTech - SETI ProbeControlEnabler",
     "identifier": "SETI-ProbeControlEnabler",
     "abstract"     : "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",

--- a/SETI-ProbeControlEnabler.netkan
+++ b/SETI-ProbeControlEnabler.netkan
@@ -6,7 +6,6 @@
     "identifier": "SETI-ProbeControlEnabler",
     "abstract"     : "This SETI version of the ProbeControlEnabler retains the integrated omni antennas (SETIrebalance) for manned command pods. Probe core integrated omni antennas still do not work (needs changes to RemoteTech, see RemoteTech github issue tracker). It was inspired by the MM config from Felger.",
     "license"	: "GPL-2.0",
-    "ksp_version_max": "1.99.99",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
     },
@@ -15,9 +14,9 @@
       	{ "name" : "RemoteTech" }
     ],
     "install" : [
-    	{ 
+    	{
         "find" : "SETIprobeControlEnabler",
-	"install_to" : "GameData" 
-      	} 
+	"install_to" : "GameData"
+      	}
     ]
 }

--- a/SETI-ProbeParts.netkan
+++ b/SETI-ProbeParts.netkan
@@ -4,12 +4,11 @@
     "$vref"         : "#/ckan/ksp-avc",
     "identifier"    : "SETI-ProbeParts",
     "x_netkan_license_ok" : true,
-    "ksp_version_max": "1.99.99",
     "depends" : [
         { "name": "ModuleManager" }
     ],
     "install" : [
-        { 
+        {
           "file"       : "SETIprobeParts",
           "install_to" : "GameData"
         }

--- a/SETI-RebalanceMaterialsGoo.netkan
+++ b/SETI-RebalanceMaterialsGoo.netkan
@@ -1,7 +1,7 @@
 {
     "$kref" : "#/ckan/github/Y3mo/SETI-RebalanceMaterialsGoo",
     "$vref" : "#/ckan/ksp-avc",
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "name": "SETI-Rebalance MaterialsBay & MysteryGoo",
     "identifier": "SETI-RebalanceMaterialsGoo",
     "abstract"     : "This is the SETI Rebalance MaterialsBay and MysteryGoo MM patch, so that those 2 experiments can not be collected by scientists anymore, which makes them much more balanced in terms of mass/science payout.",
@@ -15,7 +15,7 @@
     "install" : [
     	{
     	  "find" : "SETIrebalanceMaterialsGoo",
-    	  "install_to" : "GameData" 
-      } 
+    	  "install_to" : "GameData"
+      }
     ]
 }

--- a/SETI-RemoteTech.netkan
+++ b/SETI-RemoteTech.netkan
@@ -1,7 +1,7 @@
 {
     "$kref" : "#/ckan/github/Y3mo/SETI-RemoteTech",
     "$vref" : "#/ckan/ksp-avc",
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "name": "RemoteTech - SETI Config",
     "identifier": "SETI-RemoteTech",
     "abstract"     : "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",

--- a/SETI-RemoteTech.netkan
+++ b/SETI-RemoteTech.netkan
@@ -6,7 +6,6 @@
     "identifier": "SETI-RemoteTech",
     "abstract"     : "This is a SETI config for RemoteTech, adding ground stations, changing the KSC range to cover the whole kerbol system (when not obstructed), setting signal delay to false and tweaking some colors.",
     "license"	: "GPL-2.0",
-    "ksp_version_max": "1.99.99",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
     },
@@ -15,9 +14,9 @@
         { "name" : "RemoteTech" }
     ],
     "install" : [
-    	{ 
+    	{
         "find" : "SETIremoteTechConfig",
-	"install_to" : "GameData" 
-      } 
+	"install_to" : "GameData"
+      }
     ]
 }

--- a/UnmannedBeforeManned.netkan
+++ b/UnmannedBeforeManned.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"  : "v1.2",
+    "spec_version"  : "v1.4",
     "$kref"         : "#/ckan/spacedock/20",
     "$vref" 	    : "#/ckan/ksp-avc",
     "name"	    : "Unmanned before Manned (SETI-UbM)",

--- a/UnmannedBeforeManned.netkan
+++ b/UnmannedBeforeManned.netkan
@@ -5,7 +5,6 @@
     "name"	    : "Unmanned before Manned (SETI-UbM)",
     "identifier"    : "UnmannedBeforeManned",
     "x_netkan_license_ok" : true,
-    "ksp_version_max": "1.99.99",
     "depends" : [
         { "name": "ModuleManager" }
     ],
@@ -15,7 +14,7 @@
     		{ "name": "TakeCommandContinued" }
     ],
     "install" : [
-        { 
+        {
 	    "find"       : "UnmannedBeforeManned",
             "install_to" : "GameData"
         }

--- a/UnmannedBeforeMannedChallenge.netkan
+++ b/UnmannedBeforeMannedChallenge.netkan
@@ -1,7 +1,7 @@
 {
     "$kref" : "#/ckan/github/Y3mo/UnmannedBeforeMannedChallenge",
     "$vref" : "#/ckan/ksp-avc",
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "name": "Unmanned Before Manned Challenge (SETI-UbMchallenge)",
     "identifier": "UnmannedBeforeMannedChallenge",
     "abstract"     : "Makes UbM a bit more challenging. Reaction wheels not before 90 science, fuel lines to 550 science node, skipper engine one node later",

--- a/UnmannedBeforeMannedChallenge.netkan
+++ b/UnmannedBeforeMannedChallenge.netkan
@@ -6,7 +6,6 @@
     "identifier": "UnmannedBeforeMannedChallenge",
     "abstract"     : "Makes UbM a bit more challenging. Reaction wheels not before 90 science, fuel lines to 550 science node, skipper engine one node later",
     "license"	: "restricted",
-    "ksp_version_max": "1.99.99",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/106130"
     },
@@ -19,9 +18,9 @@
         { "name": "SETI-ProbeParts" }
     ],
     "install" : [
-    	{ 
+    	{
         "find" : "UnmannedBeforeMannedChallenge",
-         "install_to" : "GameData" 
-      } 
+         "install_to" : "GameData"
+      }
     ]
 }


### PR DESCRIPTION
Many of the mods in this repo have `"ksp_version_max": "1.99.99",` but KSP-CKAN/NetKAN#7406 alleges that they "are incompatible with current module manager versions and show werid buggy behaviour on current ksp versions." In other words, this property is not accurate.

This PR removes that line. The modules' compatibility will be marked according to how it is SpaceDock or in their `.version` files.